### PR TITLE
Add MER and SBR + Divide by decimals

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,12 +12,14 @@ const OBLIGATION_LEN = 1300;
 const RESERVES_TO_ASSET_MAP = {
   "8PbodeaosQP19SjYFx855UMqWxH2HynZLdBXmsrbac36": "SOL",
   "BgxfHJDzm44T7XG68MYKx7YisTjZu73tVovyZSjJMpmw": "USDC",
+  "8K9WC8xoh2rtQNY7iEGXtPvfbDCi563SdWhCAhuMP2xE": "USDT",
   "3PArRsZQ6SLkr1WERZWyC6AqsajtALMq4C66ZMYz4dKQ": "ETH",
   "GYzjMCXTDue12eUGKKWAqtF5jcBYNmewr6Db6LaguEaX": "BTC",
-  "8K9WC8xoh2rtQNY7iEGXtPvfbDCi563SdWhCAhuMP2xE": "USDT",
-  "9n2exoMQwMTzfw6NFoFFujxYPndWVLtKREJePssrKb36": "RAY",
   "5suXmvdbKQ98VonxGCXqViuWRu8k4zgZRxndYKsH2fJg": "SRM",
   "2dC4V23zJxuv521iYQj8c471jrxYLNQFaGS6YPwtTHMd": "FTT",
+  "9n2exoMQwMTzfw6NFoFFujxYPndWVLtKREJePssrKb36": "RAY",
+  "Hthrt4Lab21Yz1Dx9Q4sFW4WVihdBUTtWRQBjPsYHCor": "SBR",
+  "5Sb6wDpweg6mtYksPJ2pfGbSyikrhR8Ut8GszcULQ83A": "MER"
 };
 
 async function main() {

--- a/index.js
+++ b/index.js
@@ -11,9 +11,13 @@ const LENDING_MARKET_MAIN = "4UpD2fh7xH3VP9QQaXtsS1YY3bxzWhtfpks7FatyKvdY";
 const OBLIGATION_LEN = 1300;
 const RESERVES_TO_ASSET_MAP = {
   "8PbodeaosQP19SjYFx855UMqWxH2HynZLdBXmsrbac36": "SOL",
-  BgxfHJDzm44T7XG68MYKx7YisTjZu73tVovyZSjJMpmw: "USDC",
+  "BgxfHJDzm44T7XG68MYKx7YisTjZu73tVovyZSjJMpmw": "USDC",
   "3PArRsZQ6SLkr1WERZWyC6AqsajtALMq4C66ZMYz4dKQ": "ETH",
-  GYzjMCXTDue12eUGKKWAqtF5jcBYNmewr6Db6LaguEaX: "BTC",
+  "GYzjMCXTDue12eUGKKWAqtF5jcBYNmewr6Db6LaguEaX": "BTC",
+  "8K9WC8xoh2rtQNY7iEGXtPvfbDCi563SdWhCAhuMP2xE": "USDT",
+  "9n2exoMQwMTzfw6NFoFFujxYPndWVLtKREJePssrKb36": "RAY",
+  "5suXmvdbKQ98VonxGCXqViuWRu8k4zgZRxndYKsH2fJg": "SRM",
+  "2dC4V23zJxuv521iYQj8c471jrxYLNQFaGS6YPwtTHMd": "FTT",
 };
 
 async function main() {

--- a/index.js
+++ b/index.js
@@ -21,16 +21,33 @@ const RESERVES_TO_ASSET_MAP = {
   "Hthrt4Lab21Yz1Dx9Q4sFW4WVihdBUTtWRQBjPsYHCor": "SBR",
   "5Sb6wDpweg6mtYksPJ2pfGbSyikrhR8Ut8GszcULQ83A": "MER"
 };
+const ASSET_TO_DECIMALS = {
+  "SOL": 9,
+  "USDC": 6,
+  "ETH": 6,
+  "BTC": 6,
+  "SRM": 6,
+  "USDT": 6,
+  "MER": 6,
+  "FTT": 6,
+  "SBR": 6,
+  "UST": 9,
+  "RAY":6
+};
 
 async function main() {
   const [totalDeposits, totalBorrows] = await getTotalDepositsAndBorrows();
   console.log("Total Deposits:");
-  for (const [reserve, balance] of Object.entries(totalDeposits)) {
-    console.log(reserve, balance.toString());
+  for (const [asset, rawBalance] of Object.entries(totalDeposits)) {
+    const balance = rawBalance.div(new BN(10 ** ASSET_TO_DECIMALS[asset]));
+    console.log(asset, balance.toString());
   }
+  
+  console.log("\n");
   console.log("Total Borrows:");
-  for (const [reserve, balance] of Object.entries(totalBorrows)) {
-    console.log(reserve, balance.toString());
+  for (const [asset, rawBalance] of Object.entries(totalBorrows)) {
+    const balance = rawBalance.div(new BN(10 ** ASSET_TO_DECIMALS[asset]));
+    console.log(asset, balance.toString());
   }
 }
 


### PR DESCRIPTION
_Requires #1 by @m30m_

- Re-order tokens to match ordering in production reserves list: https://github.com/solendprotocol/common/blob/master/src/production.json#L95
- Add SBR and MER
- This update prevents a bunch of errors being logged for each user that has interacted with SBR and MER
- Divide the token amounts by their number of decimals to enable easier comparison with the Solend UI